### PR TITLE
Check that file exists not if it's a file

### DIFF
--- a/.zlogout
+++ b/.zlogout
@@ -1,5 +1,5 @@
 # If connected remote
 if [ ! -z "$SSH_TTY" ]; then
     # cleanup remote gpg agent socket
-    [ -f ~/.gnupg/S.gpg-agent ] && rm ~/.gnupg/S.gpg-agent
+    [ -e ~/.gnupg/S.gpg-agent ] && rm ~/.gnupg/S.gpg-agent
 fi


### PR DESCRIPTION
Checking if it's a file does not actually work, therefore this never cleans up the socket when you're doing a forward from a remote system. Changing this to -e will just check for existence and remove.